### PR TITLE
Fix: Increase default font size from 16px to 18px

### DIFF
--- a/apps/readest-app/src/app/reader/components/footerbar/FontLayoutPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/footerbar/FontLayoutPanel.tsx
@@ -11,7 +11,7 @@ import Slider from '@/components/Slider';
 const FONT_SIZE_LIMITS = {
   MIN: 8,
   MAX: 30,
-  DEFAULT: 16,
+  DEFAULT: 18,
 } as const;
 
 const LINE_HEIGHT_LIMITS = {

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -118,7 +118,7 @@ export const DEFAULT_BOOK_FONT: BookFont = {
   monospaceFont: 'Consolas',
   defaultFont: 'Serif',
   defaultCJKFont: 'LXGW WenKai GB Screen',
-  defaultFontSize: 16,
+  defaultFontSize: 18,
   minimumFontSize: 8,
   fontWeight: 400,
 };


### PR DESCRIPTION
## Summary
Increases the default font size from 16px to 18px to improve readability in the ebook reader.

## Changes
- Updated `DEFAULT_BOOK_FONT.defaultFontSize` in `apps/readest-app/src/services/constants.ts` from 16 to 18
- Updated `FONT_SIZE_LIMITS.DEFAULT` in `apps/readest-app/src/app/reader/components/footerbar/FontLayoutPanel.tsx` from 16 to 18

## Why this change?
The default font size of 16px was reported as too small for comfortable reading. The new default of 18px provides better text legibility while maintaining the existing font size range (8-30px) that users can adjust through the settings.

## Testing
- Font size constants have been updated
- The change maintains backward compatibility with existing user preferences
- Users who have already customized their font size will not be affected

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)